### PR TITLE
Minor fixes to segment bound calculation and machVmAllocate

### DIFF
--- a/go/kernel/mach/mman.go
+++ b/go/kernel/mach/mman.go
@@ -5,7 +5,7 @@ import (
 	"github.com/lunixbochs/usercorn/go/kernel/posix"
 )
 
-func (k *MachKernel) KernelrpcMachVmAllocateTrap(unk int, size co.Len, addrOut co.Buf) uint64 {
+func (k *MachKernel) KernelrpcMachVmAllocateTrap(target int, addrOut co.Obuf, size co.Len, flags int) uint64 {
 	mmap, err := k.U.Mmap(0, uint64(size))
 	if err != nil {
 		return posix.UINT64_MAX // FIXME
@@ -18,7 +18,7 @@ func (k *MachKernel) KernelrpcMachVmAllocateTrap(unk int, size co.Len, addrOut c
 	return 0
 }
 
-func (k *MachKernel) KernelrpcMachVmDeallocateTrap() uint64 {
+func (k *MachKernel) KernelrpcMachVmDeallocateTrap(target int, addr co.Buf, size co.Len) uint64 {
 	//TODO: implement
 	return 0
 }

--- a/go/usercorn.go
+++ b/go/usercorn.go
@@ -645,6 +645,7 @@ func (u *Usercorn) mapBinary(f *os.File, isInterp bool, arch string) (interpBase
 		return
 	}
 	var low, high uint64
+	low = 0xffffffffffffffff
 	for _, seg := range segments {
 		if seg.Addr < low {
 			low = seg.Addr
@@ -653,6 +654,9 @@ func (u *Usercorn) mapBinary(f *os.File, isInterp bool, arch string) (interpBase
 		if h > high {
 			high = h
 		}
+	}
+	if low > high {
+		low = high
 	}
 	// map contiguous binary
 	loadBias := u.config.ForceBase


### PR DESCRIPTION
Lower bound was not initialized before being checked against segment addresses.

MachVmAllocate had wrong parameters resulting in "size" being confused with "addr".