### PR TITLE
Added clarification about BusyBox being run x86_64

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Caveats
 
 - Your userspace might be incredibly confusing to the target binary.
 - No API for memory mapped files yet (kinda, if mmap() currently gets a file descriptor argument it will manually copy the file into memory).
-- I only have maybe 20% of the posix syscalls implemented, which is enough to run basic binaries. Busybox works great. Dynamically linked stuff not so much. I keep breaking this, and I probably need to rework the TLS and x86 segment stuff again.
+- I only have maybe 20% of the posix syscalls implemented, which is enough to run basic binaries. Busybox (x86_64) works great. Dynamically linked stuff not so much. I keep breaking this, and I probably need to rework the TLS and x86 segment stuff again.
 
 [See Also](https://xkcd.com/1406/)
 ----


### PR DESCRIPTION
Out of the box, BusyBox only runs on x86_64.

```
dave@universal:~/usercorn$ ./usercorn busybox-x86_64 cat --version
cat: unrecognized option `--version'
BusyBox v1.21.1 (2013-07-08 11:34:59 CDT) multi-call binary.

Usage: cat [FILE]...

Concatenate FILEs and print them to stdout

dave@universal:~/usercorn$ ./usercorn busybox-i486 cat --version
invalid write: @0xf710, 0x4 = 0x8065d6a
[memory map]
  0x60000000-0x60800000 rwx [stack]
  0x60800000-0x60801000 ---
  0x8048000-0x811d000 r-x busybox-i486 [exe]
  0x811d000-0x8123000 rw- busybox-i486 [exe]
  0x8123000-0x8124000 rw- [brk]
  0x8124000-0x8125000 rw- [brk]
  0x100000-0x101000 rwx
[registers]
   cs 0x00000000   ebx 0x607ff720  eflags 0x00000000   esp 0x607ff714
   ds 0x00000000   ecx 0x00000000   eip 0x08065d65    fs 0x00000000
  eax 0x00000002   edi 0x00000001    es 0x00000000    gs 0x00000002
  ebp 0x00000010   edx 0x08124000   esi 0x00000000    ss 0x00000000
[stacktrace]
  0x8065d65
panic: ^C
dave@universal:~/usercorn$ ./usercorn busybox-i686 cat --version
invalid write: @0xf6dc, 0x4 = 0x8067420
[memory map]
  0x60000000-0x60800000 rwx [stack]
  0x60800000-0x60801000 ---
  0x8048000-0x811f000 r-x busybox-i686 [exe]
  0x811f000-0x8125000 rw- busybox-i686 [exe]
  0x8125000-0x8126000 rw- [brk]
  0x8126000-0x8127000 rw- [brk]
  0x100000-0x101000 rwx
[registers]
   cs 0x00000000   ebx 0x607ff6ec  eflags 0x00000000   esp 0x607ff6e0
   ds 0x00000000   ecx 0x00000000   eip 0x0806741b    fs 0x00000000
  eax 0x00000002   edi 0x00000001    es 0x00000000    gs 0x00000002
  ebp 0x00000000   edx 0x00000000   esi 0x00000000    ss 0x00000000
[stacktrace]
  0x806741b
panic: ^C
dave@universal:~/usercorn$ ./usercorn busybox-mips cat --version
invalid read: @0xffff9c27, 0x2 = 0x0
[memory map]
  0x60000000-0x60800000 rwx [stack]
  0x60800000-0x60801000 ---
  0x400000-0x57d000 r-x busybox-mips [exe]
  0x58d000-0x595000 rw- busybox-mips [exe]
  0x595000-0x596000 rw- [brk]
[registers]
   at 0x00000000    a3 0x00000000    s4 0x00000000    t2 0x00000000
   gp 0x00000000    k0 0x00000000    s5 0x00000000    t3 0x00000000
   ra 0x00000000    k1 0x00000000    s6 0x00000000    t4 0x00000000
   sp 0x607ff838    s0 0x00000000    s7 0x00000000    t5 0x00000000
   a0 0x00000000    s1 0x00000000    s8 0x00000000    t6 0x00000000
   a1 0x00000000    s2 0x00000000    t0 0x00000000    t7 0x00000000
   a2 0x00000000    s3 0x00000000    t1 0x00000000    t8 0x00000000
                    t9 0x00000000    v0 0x00000000    v1 0x00000000
[stacktrace]
  0x400290
panic: ^C
```
