### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/go/lua/repl.go
+++ b/go/lua/repl.go
@@ -22,7 +22,7 @@ type LuaRepl struct {
 
 // TODO: eventually support multiple usercorn instances in a repl
 
-// Return a new lua repl bound to a Usercorn instance.
+// NewRepl returns a new lua repl bound to a Usercorn instance.
 func NewRepl(u models.Usercorn, o io.Writer) (*LuaRepl, error) {
 	repl := &LuaRepl{
 		LState: lua.NewState(),
@@ -48,7 +48,7 @@ func (l *LuaRepl) SetOutput(w io.Writer) {
 	l.Writer = w
 }
 
-// Writes emulator state to lua globals.
+// EnvToLua writes emulator state to lua globals.
 func (L *LuaRepl) EnvToLua() {
 	u := L.u
 	vals, err := u.RegDump()

--- a/go/models/breakpoint.go
+++ b/go/models/breakpoint.go
@@ -126,7 +126,7 @@ outer:
 	return nil
 }
 
-// removes all Unicorn hooks added by this breakpoint
+// Remove removes all Unicorn hooks added by this breakpoint
 func (b *Breakpoint) Remove() error {
 	for _, hook := range b.hooks {
 		b.u.HookDel(hook.hook)

--- a/go/models/cpu/mem.go
+++ b/go/models/cpu/mem.go
@@ -78,7 +78,7 @@ func (m *Mem) MemWrite(addr uint64, p []byte) error {
 	return m.Sim.Write(addr, p, 0)
 }
 
-// Read while checking protections. This exists to support a CPU interpreter.
+// ReadProt reads while checking protections. This exists to support a CPU interpreter.
 func (m *Mem) ReadProt(addr, size uint64, prot int) ([]byte, error) {
 	p := make([]byte, size)
 	if err := m.Sim.Read(addr, p, prot); err != nil {
@@ -96,7 +96,7 @@ func (m *Mem) ReadProt(addr, size uint64, prot int) ([]byte, error) {
 	return p, nil
 }
 
-// Write while checking protections. This exists to support a CPU interpreter.
+// WriteProt writes while checking protections. This exists to support a CPU interpreter.
 // Write hooks trigger in WriteUint for now.
 func (m *Mem) WriteProt(addr uint64, p []byte, prot int) error {
 	return m.Sim.Write(addr, p, prot)
@@ -113,7 +113,7 @@ func (m *Mem) ReadUint(addr uint64, size, prot int) (uint64, error) {
 	return UnpackUint(m.order, size, p)
 }
 
-// write hook only triggers here, as we can't fill value in WriteProt
+// WriteUint writes hook only triggers here, as we can't fill value in WriteProt
 func (m *Mem) WriteUint(addr uint64, size, prot int, val uint64) error {
 	var buf [8]byte
 	if size > 8 {

--- a/go/models/cpu/memsim.go
+++ b/go/models/cpu/memsim.go
@@ -34,7 +34,7 @@ type MemSim struct {
 	Mem Pages
 }
 
-// Checks whether the address range exists in the currently-mapped memory.
+// RangeValid checks whether the address range exists in the currently-mapped memory.
 // If prot > 0, ensures that each region has the entire protection mask provided.
 func (m *MemSim) RangeValid(addr, size uint64, prot int) (mapGood bool, protGood bool) {
 	_, first := m.Mem.bsearch(addr)
@@ -77,7 +77,7 @@ func (m *MemSim) Map(addr, size uint64, prot int, zero bool) *Page {
 	return page
 }
 
-// this is *exactly* unmap, but the "middle" pages of each split are re-protected
+// Prot is *exactly* unmap, but the "middle" pages of each split are re-protected
 func (m *MemSim) Prot(addr, size uint64, prot int) {
 	// truncate entries overlapping addr, size
 	tmp := make([]*Page, 0, len(m.Mem))

--- a/go/models/cpu/page.go
+++ b/go/models/cpu/page.go
@@ -62,7 +62,7 @@ func (p *Page) Contains(addr uint64) bool {
 	return addr >= p.Addr && addr < p.Addr+p.Size
 }
 
-// start = max(s1, s2), end = min(e1, e2), ok = end > start
+// Intersect starts = max(s1, s2), end = min(e1, e2), ok = end > start
 func (p *Page) Intersect(addr, size uint64) (uint64, uint64, bool) {
 	start := p.Addr
 	end := p.Addr + p.Size

--- a/go/models/trace/replay.go
+++ b/go/models/trace/replay.go
@@ -143,7 +143,7 @@ func (r *Replay) update(op models.Op) {
 	}
 }
 
-// Feed() is the entry point handling Op structs.
+// Feed is the entry point handling Op structs.
 // It calls update() and combines side-effects with instructions
 func (r *Replay) Feed(op models.Op) {
 	var ops []models.Op

--- a/go/models/trace/trace.go
+++ b/go/models/trace/trace.go
@@ -197,7 +197,7 @@ func (t *Trace) Detach() {
 	t.regs = nil
 }
 
-// this gets weird, because I want to stream some things instruction-at-a-time
+// This gets weird, because I want to stream some things instruction-at-a-time
 // but also want all of the frame information for printing where possible
 // and on the middle ground, I want register information for an instruction
 // I guess everything between an OpStep/OpJmp goes to the next OpStep/Jmp?
@@ -231,7 +231,7 @@ func (t *Trace) Rewound() {
 	}
 }
 
-// canAdvance indicates whether this op can start a new keyframe
+// indicates whether this op can start a new keyframe
 // TODO: eventually allow alternating OpFrames with Syscalls, like on windows kernel->userspace callbacks?
 func (t *Trace) Append(op models.Op, canAdvance bool) {
 	ops := []models.Op{op}

--- a/go/models/trace/tracefile.go
+++ b/go/models/trace/tracefile.go
@@ -70,7 +70,7 @@ func NewWriter(w io.WriteCloser, u models.Usercorn) (*TraceWriter, error) {
 	return &TraceWriter{w: w, zw: zw}, nil
 }
 
-// write a frame at a time
+// Pack writes a frame at a time
 func (t *TraceWriter) Pack(frame models.Op) error {
 	tmp := make([]byte, frame.Sizeof())
 	frame.Pack(tmp)

--- a/go/usercorn.go
+++ b/go/usercorn.go
@@ -348,7 +348,7 @@ func (u *Usercorn) MemRead(addr, size uint64) ([]byte, error) {
 	return p, err
 }
 
-// read without tracing, used by trace and repl
+// DirectRead reads without tracing, used by trace and repl
 func (u *Usercorn) DirectRead(addr, size uint64) ([]byte, error) {
 	return u.Task.MemRead(addr, size)
 }
@@ -966,7 +966,7 @@ func (u *Usercorn) RunAsm(addr uint64, asm string, setRegs map[int]uint64, regsC
 
 var breakRe = regexp.MustCompile(`^((?P<addr>0x[0-9a-fA-F]+|\d+)|(?P<sym>[\w:]+(?P<off>\+0x[0-9a-fA-F]+|\d+)?)|(?P<source>.+):(?P<line>\d+))(@(?P<file>.+))?$`)
 
-// adds a breakpoint to Usercorn instance
+// BreakAdd adds a breakpoint to Usercorn instance
 // see models.Breakpoint for desc syntax
 // future=true adds it to the list of breakpoints to update when new memory is mapped/registered
 func (u *Usercorn) BreakAdd(desc string, future bool, cb func(u models.Usercorn, addr uint64)) (*models.Breakpoint, error) {


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._