### PR TITLE
unstable: support linker64 on arm64 Android

### DIFF
--- a/go/cmd/cfg/arch.go
+++ b/go/cmd/cfg/arch.go
@@ -1,5 +1,6 @@
 package cfg
 
+/*
 import (
 	cs "github.com/bnagy/gapstone"
 
@@ -53,3 +54,4 @@ func ArchConfig(u models.Usercorn) *archConfig {
 		panic("unknown arch")
 	}
 }
+*/

--- a/go/kernel/linux/elf_auxv.go
+++ b/go/kernel/linux/elf_auxv.go
@@ -28,6 +28,7 @@ const (
 	ELF_AT_PLATFORM
 	ELF_AT_HWCAP
 	ELF_AT_CLKTCK       = 17
+	ELF_AT_SECURE       = 23
 	ELF_AT_RANDOM       = 25
 	ELF_AT_SYSINFO      = 32
 	ELF_AT_SYSINFO_EHDR = 33
@@ -69,6 +70,7 @@ func setupElfAuxv(u models.Usercorn) ([]ElfAuxv, error) {
 		{ELF_AT_EGID, uint64(os.Getegid())},
 		{ELF_AT_PLATFORM, platformAddr},
 		{ELF_AT_CLKTCK, 100}, // 100hz, totally fake
+		{ELF_AT_SECURE, 0}, // TODO: (getuid() != geteuid() || getgid() != getegid())
 		{ELF_AT_RANDOM, randAddr},
 		{ELF_AT_NULL, 0},
 	}
@@ -87,7 +89,7 @@ func setupElfAuxv(u models.Usercorn) ([]ElfAuxv, error) {
 	}
 	if phdrOff > 0 {
 		auxv = append([]ElfAuxv{
-			{ELF_AT_PHDR, phdrOff},
+			{ELF_AT_PHDR, u.Base() + phdrOff},
 			{ELF_AT_PHENT, uint64(phdrEnt)},
 			{ELF_AT_PHNUM, uint64(phdrCount)},
 		}, auxv...)

--- a/go/kernel/linux/kernel.go
+++ b/go/kernel/linux/kernel.go
@@ -10,12 +10,25 @@ const (
 	STACK_SIZE = 0x00800000
 )
 
+
+type sigaltstack_t struct {
+	Stackpointer uint64
+	Size         int64
+	Flags        int64
+}
+
 type LinuxKernel struct {
 	posix.PosixKernel
+	CurrentStack sigaltstack_t
+	IsDumpable uint64
 }
 
 func NewKernel() *LinuxKernel {
-	kernel := &LinuxKernel{*posix.NewKernel()}
+	kernel := &LinuxKernel{
+		*posix.NewKernel(),
+		sigaltstack_t{},
+		1,
+	}
 	registerUnpack(kernel)
 	kernel.Pack = Pack
 	return kernel

--- a/go/kernel/linux/prctl.go
+++ b/go/kernel/linux/prctl.go
@@ -9,18 +9,16 @@ const (
 	PR_SET_DUMPABLE = 0x4
 )
 
-var IsDumpable uint64 = 1
-
 func (k *LinuxKernel) Prctl(code int, arg uint64) uint64 {
 	switch code {
 	case PR_SET_VMA:
 		//TODO: if there is ever an Android kernel, this is Android only
 		return 0
 	case PR_GET_DUMPABLE:
-		return IsDumpable
+		return k.IsDumpable
 	case PR_SET_DUMPABLE:
 	if arg == 0 || arg == 1 {
-		IsDumpable = arg
+		k.IsDumpable = arg
 		return 0
 	} else {
 		return UINT64_MAX

--- a/go/kernel/linux/prctl.go
+++ b/go/kernel/linux/prctl.go
@@ -1,0 +1,30 @@
+package linux
+
+import "fmt"
+
+// TODO: put these somewhere. ghostrace maybe.
+const (
+	PR_SET_VMA = 0x53564d41
+	PR_GET_DUMPABLE = 0x3
+	PR_SET_DUMPABLE = 0x4
+)
+
+var IsDumpable uint64 = 1
+
+func (k *LinuxKernel) Prctl(code int, arg uint64) uint64 {
+	switch code {
+	case PR_SET_VMA:
+		//TODO: if there is ever an Android kernel, this is Android only
+		return 0
+	case PR_GET_DUMPABLE:
+		return IsDumpable
+	case PR_SET_DUMPABLE:
+	if arg == 0 || arg == 1 {
+		IsDumpable = arg
+		return 0
+	} else {
+		return UINT64_MAX
+	}
+	}
+	panic(fmt.Sprintf("unhandled prctl code: 0x%x", code))
+}

--- a/go/kernel/linux/random.go
+++ b/go/kernel/linux/random.go
@@ -1,0 +1,17 @@
+package linux
+
+import (
+	"crypto/rand"
+	co "github.com/lunixbochs/usercorn/go/kernel/common"
+)
+
+func (k *LinuxKernel) Getrandom(buf co.Obuf, size uint64, flags uint32) uint64 {
+	tmp := make([]byte, size)
+	n, _ := rand.Read(tmp)
+	tmp = tmp[:n]
+	if err := buf.Pack(tmp); err != nil {
+		return UINT64_MAX
+	}
+	return uint64(n)
+}
+

--- a/go/kernel/linux/signal.go
+++ b/go/kernel/linux/signal.go
@@ -4,14 +4,6 @@ import (
 	"github.com/lunixbochs/usercorn/go/kernel/common"
 )
 
-type sigaltstack_t struct {
-	Stackpointer uint64
-	Size         int64
-	Flags        int64
-}
-
-var CurrentStack sigaltstack_t
-
 const (
 	SS_ONSTACK = 1
 	SS_DISABLE = 2
@@ -22,10 +14,10 @@ const (
 func (k *LinuxKernel) Sigaltstack(nss common.Buf, oss common.Obuf) uint64 {
 	//TODO: track the flags properly
 	if oss.Addr != 0 {
-		oss.Pack(&CurrentStack)
+		oss.Pack(&k.CurrentStack)
 	}
 	if nss.Addr != 0 {
-		if err := nss.Unpack(&CurrentStack); err != nil {
+		if err := nss.Unpack(&k.CurrentStack); err != nil {
 			return 1
 		}
 	}

--- a/go/kernel/linux/signal.go
+++ b/go/kernel/linux/signal.go
@@ -1,0 +1,33 @@
+package linux
+
+import (
+	"github.com/lunixbochs/usercorn/go/kernel/common"
+)
+
+type sigaltstack_t struct {
+	Stackpointer uint64
+	Size         int64
+	Flags        int64
+}
+
+var CurrentStack sigaltstack_t
+
+const (
+	SS_ONSTACK = 1
+	SS_DISABLE = 2
+	SS_AUTODISARM = 1 << 31
+	SS_FLAG_BITS = SS_AUTODISARM
+)
+
+func (k *LinuxKernel) Sigaltstack(nss common.Buf, oss common.Obuf) uint64 {
+	//TODO: track the flags properly
+	if oss.Addr != 0 {
+		oss.Pack(&CurrentStack)
+	}
+	if nss.Addr != 0 {
+		if err := nss.Unpack(&CurrentStack); err != nil {
+			return 1
+		}
+	}
+	return 0
+}

--- a/go/kernel/linux/thread.go
+++ b/go/kernel/linux/thread.go
@@ -50,6 +50,10 @@ func (k *LinuxKernel) SetTidAddress(tidptr co.Buf) uint64 {
 	return 0
 }
 
+func (k *LinuxKernel) Tgkill(tgid int, tid int, sig int) uint64 {
+	return 0
+}
+
 /*
 long get_robust_list(int pid, struct robust_list_head **head_ptr,
                      size_t *len_ptr);

--- a/go/kernel/posix/sched.go
+++ b/go/kernel/posix/sched.go
@@ -1,0 +1,20 @@
+package posix
+
+import "syscall"
+
+const (
+	SCHED_NORMAL = 0
+	SCHED_FIFO = 1
+	SCHED_RR = 2
+	SCHED_BATCH = 3
+	SCHED_ISO = 4
+	SCHED_IDLE = 5
+	SCHED_DEADLINE =6
+)
+
+func (k *PosixKernel) SchedGetscheduler(pid int) int64 {
+	if pid < 0 {
+		return int64(syscall.EINVAL)
+	}
+	return SCHED_NORMAL
+}


### PR DESCRIPTION
This was tested on Android 7.1.2 and will not work on Android 8 due to Unicorn not handling the CASA (http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0801h/bzf1476202789613.html) instructions that started appearing in builds then.

To test functionality, use the following commands. The linker spits out some warnings but otherwise works fine.

```bash
$ git clone git@github.com:afrocheese/usercorn.git
$ cd usercorn
$ git checkout unstable
$ make deps && make
$ unzip android-arm64-test.zip
$ ./usercorn run -prefix rootfs bins/hello-arm64
hello world
```
Android support files: [android-arm64-test.zip](https://github.com/lunixbochs/usercorn/files/2968114/android-arm64-test.zip)