### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:18.04
+RUN apt update && \
+    apt -y install --no-install-recommends gcc-multilib g++-multilib git cmake \
+                                           gcc g++ pkg-config libglib2.0-dev curl
+
+# Install python3.8
+RUN apt -y install --no-install-recommends software-properties-common \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt update \
+    && apt -y install python3.8-dev python3.8-venv python3-pip
+RUN python3.8 -m venv /root/py38
+ENV PATH="/root/py38/bin:${PATH}"
+
+RUN git clone -b unstable https://github.com/lunixbochs/usercorn.git /usercorn
+WORKDIR /usercorn
+RUN make deps
+RUN make
+RUN ln -s /usercorn/usercorn /usr/bin/


### PR DESCRIPTION
Adds a simple dockerfile.

We can play around with how this is built. This works well to play with usercorn.

Note that if we want a dockerfile for _development_ we probably want to use `COPY` to copy in the repo instead of a fresh clone (so they can build in their changes).

This is just a sample, for you to play with.

`docker build . -t usercorn`
`docker run -it usercorn bash`