### PR TITLE
Do not panic on prctl call with option PR_SET_TAGGED_ADDR_CTRL

### DIFF
--- a/go/kernel/linux/prctl.go
+++ b/go/kernel/linux/prctl.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // TODO: put these somewhere. ghostrace maybe.
 const (
-	PR_SET_VMA = 0x53564d41
+	PR_SET_VMA      = 0x53564d41
 	PR_GET_DUMPABLE = 0x3
 	PR_SET_DUMPABLE = 0x4
 )
@@ -17,12 +17,12 @@ func (k *LinuxKernel) Prctl(code int, arg uint64) uint64 {
 	case PR_GET_DUMPABLE:
 		return k.IsDumpable
 	case PR_SET_DUMPABLE:
-	if arg == 0 || arg == 1 {
-		k.IsDumpable = arg
-		return 0
-	} else {
-		return UINT64_MAX
-	}
+		if arg == 0 || arg == 1 {
+			k.IsDumpable = arg
+			return 0
+		} else {
+			return UINT64_MAX
+		}
 	}
 	panic(fmt.Sprintf("unhandled prctl code: 0x%x", code))
 }

--- a/go/kernel/linux/prctl.go
+++ b/go/kernel/linux/prctl.go
@@ -1,12 +1,16 @@
 package linux
 
-import "fmt"
+import (
+	"fmt"
+	"syscall"
+)
 
 // TODO: put these somewhere. ghostrace maybe.
 const (
-	PR_SET_VMA      = 0x53564d41
-	PR_GET_DUMPABLE = 0x3
-	PR_SET_DUMPABLE = 0x4
+	PR_SET_VMA              = 0x53564d41
+	PR_GET_DUMPABLE         = 0x3
+	PR_SET_DUMPABLE         = 0x4
+	PR_SET_TAGGED_ADDR_CTRL = 55
 )
 
 func (k *LinuxKernel) Prctl(code int, arg uint64) uint64 {
@@ -23,6 +27,8 @@ func (k *LinuxKernel) Prctl(code int, arg uint64) uint64 {
 		} else {
 			return UINT64_MAX
 		}
+	case PR_SET_TAGGED_ADDR_CTRL:
+		return uint64(syscall.EINVAL)
 	}
 	panic(fmt.Sprintf("unhandled prctl code: 0x%x", code))
 }


### PR DESCRIPTION
When [Android's libc (bionic) tries to use the syscall prctl(PR_SET_TAGGED_ADDR_CTRL, 0x1,0,0,0)](https://cs.android.com/android/platform/superproject/+/master:bionic/libc/bionic/libc_init_static.cpp;drc=dc7efaec81b564f1b0fbabca25ca694755986db6;l=333), usercorn panics:

```
+++ caught panic +++
unhandled prctl code: 0x37
```

This PR fixes this issue. No implementation of PR_SET_TAGGED_ADDR_CTRL was implemented, as bionic can handle kernels that do not support this.

Pull request made against build-tmp, because master and unstable do not build.