### PR TITLE
Prctl warn on unsupported option

### DIFF
--- a/go/kernel/linux/prctl.go
+++ b/go/kernel/linux/prctl.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // TODO: put these somewhere. ghostrace maybe.
 const (
-	PR_SET_VMA = 0x53564d41
+	PR_SET_VMA      = 0x53564d41
 	PR_GET_DUMPABLE = 0x3
 	PR_SET_DUMPABLE = 0x4
 )
@@ -17,12 +17,12 @@ func (k *LinuxKernel) Prctl(code int, arg uint64) uint64 {
 	case PR_GET_DUMPABLE:
 		return k.IsDumpable
 	case PR_SET_DUMPABLE:
-	if arg == 0 || arg == 1 {
-		k.IsDumpable = arg
-		return 0
-	} else {
-		return UINT64_MAX
-	}
+		if arg == 0 || arg == 1 {
+			k.IsDumpable = arg
+			return 0
+		} else {
+			return UINT64_MAX
+		}
 	}
 	panic(fmt.Sprintf("unhandled prctl code: 0x%x", code))
 }

--- a/go/kernel/linux/prctl.go
+++ b/go/kernel/linux/prctl.go
@@ -1,6 +1,10 @@
 package linux
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
 
 // TODO: put these somewhere. ghostrace maybe.
 const (
@@ -24,5 +28,6 @@ func (k *LinuxKernel) Prctl(code int, arg uint64) uint64 {
 			return UINT64_MAX
 		}
 	}
-	panic(fmt.Sprintf("unhandled prctl code: 0x%x", code))
+	fmt.Fprintf(os.Stderr, "WARNING: unsupported prctl option 0x%x\n", code)
+	return uint64(syscall.EINVAL)
 }


### PR DESCRIPTION
Alternative to https://github.com/lunixbochs/usercorn/pull/331 . When tracing, the warning is inserted between the cpu instructions:

```
__dl__Z15__libc_init_mtePKvmm+0x19c
0x90ff10: movz x8, #0xa7                                     |  x8 = 0x00000000000000a7
WARNING: unsupported prctl option 0x37
0x90ff14: svc #0                                             |  x0 = 0x0000000000000016
prctl(55, 0x1) = 0x16
```
[Setsockopt](https://github.com/lunixbochs/usercorn/blob/e33dc893f4d261c3b9141abef3ed0f41ec2e603b/go/kernel/posix/socket.go#L76) seems to behave the same though.